### PR TITLE
refactor: do not return Result from set_timeout

### DIFF
--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -94,10 +94,8 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
     }
 
     /// Set read and write timeout.
-    pub fn set_timeout(&mut self, duration: Option<Duration>) -> io::Result<()> {
+    pub fn set_timeout(&mut self, duration: Option<Duration>) {
         self.timeout = duration;
-
-        Ok(())
     }
 
     /// Get the read and write timeout.

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -287,7 +287,7 @@ impl<'a> SmtpTransport {
                 )
                 .await?;
 
-            client.set_timeout(self.client_info.timeout)?;
+            client.set_timeout(self.client_info.timeout);
             let _response = client.read_response().await?;
         }
 


### PR DESCRIPTION
It is simply a setter and never returns an error.