### PR TITLE
refactor: remove Option unwraps (except for /usr/bin/sendmail part)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
     unstable_features,
     unused_import_braces,
     missing_debug_implementations,
-    clippy::result_unwrap_used
+    clippy::result_unwrap_used,
+    clippy::option_unwrap_used
 )]
 
 pub mod error;

--- a/src/sendmail/mod.rs
+++ b/src/sendmail/mod.rs
@@ -40,6 +40,7 @@ impl SendmailTransport {
     }
 }
 
+#[allow(clippy::option_unwrap_used)]
 #[async_trait]
 impl<'a> Transport<'a> for SendmailTransport {
     type Result = SendmailResult;

--- a/src/smtp/commands.rs
+++ b/src/smtp/commands.rs
@@ -166,8 +166,8 @@ pub struct HelpCommand {
 impl Display for HelpCommand {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.write_str("HELP")?;
-        if self.argument.is_some() {
-            write!(f, " {}", self.argument.as_ref().unwrap())?;
+        if let Some(arg) = &self.argument {
+            write!(f, " {}", arg)?;
         }
         f.write_str("\r\n")
     }
@@ -262,7 +262,12 @@ impl Display for AuthCommand {
             .map(|r| base64::encode_config(r.as_bytes(), base64::STANDARD));
 
         if self.mechanism.supports_initial_response() {
-            write!(f, "AUTH {} {}", self.mechanism, encoded_response.unwrap())?;
+            write!(
+                f,
+                "AUTH {} {}",
+                self.mechanism,
+                encoded_response.unwrap_or_default()
+            )?;
         } else {
             match encoded_response {
                 Some(response) => f.write_str(&response)?,

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -38,6 +38,7 @@ pub enum Error {
     /// Parsing error
     Parsing(nom::error::ErrorKind),
     Timeout(async_std::future::TimeoutError),
+    NoStream,
     NoServerInfo,
 }
 
@@ -70,6 +71,7 @@ impl StdError for Error {
             Tls(ref err) => err.description(),
             Parsing(ref err) => err.description(),
             Timeout(ref err) => err.description(),
+            NoStream => "no stream",
             NoServerInfo => "no server info",
         }
     }


### PR DESCRIPTION
This PR is related to issue #7
