### PR TITLE
Add support for tokio as well as async-std via feature flags (incomplete)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,21 @@ log = "^0.4"
 nom = { version = "^5.0", optional = true }
 bufstream = { version = "^0.1", optional = true }
 base64 = { version = "^0.11", optional = true }
+futures = "0.3.4"
 hostname = { version = "0.1.5", optional = true }
 serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
 fast_chemail = "^0.9"
-async-native-tls = "0.3.1"
-async-std = { version = "1.4", features = ["unstable"] }
+async-native-tls = { version = "0.3.1", default_features = false }
 async-trait = "0.1.17"
 pin-project = "0.4.5"
 pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.9"
+
+# Supported Runtimes
+async-std = { version = "1.4", features = ["unstable"], optional = true }
+tokio = { version = "0.2", features = ["full"], optional = true }
 
 [dev-dependencies]
 env_logger = "^0.7"
@@ -52,6 +56,10 @@ file-transport = ["serde-impls", "serde_json"]
 smtp-transport = ["bufstream", "base64", "nom", "hostname"]
 sendmail-transport = []
 native-tls-vendored = ["async-native-tls/vendored"]
+
+# Runtime
+runtime-tokio = ["tokio", "async-native-tls/runtime-tokio"]
+runtime-async-std = ["async-std", "async-native-tls/runtime-async-std"]
 
 [[example]]
 name = "smtp"

--- a/src/file/error.rs
+++ b/src/file/error.rs
@@ -1,6 +1,6 @@
 //! Error and result type for file transport
 
-use async_std::io;
+use std::io::Error as IoError;
 use serde_json;
 
 /// An enum of all error kinds.
@@ -11,7 +11,7 @@ pub enum Error {
     Client(&'static str),
     /// IO error
     #[error("io error: {0}")]
-    Io(#[from] io::Error),
+    Io(#[from] IoError),
     /// JSON serialization error
     #[error("serialization error: {0}")]
     JsonSerialization(#[from] serde_json::Error),

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -4,10 +4,8 @@
 //!
 
 use std::path::PathBuf;
+use std::path::Path;
 
-use async_std::fs::File;
-use async_std::path::Path;
-use async_std::prelude::*;
 use async_trait::async_trait;
 use serde_json;
 
@@ -15,6 +13,10 @@ use crate::file::error::FileResult;
 use crate::Envelope;
 use crate::SendableEmail;
 use crate::Transport;
+use crate::runtime::{
+    AsyncWriteExt,
+    File
+};
 
 pub mod error;
 
@@ -64,6 +66,9 @@ impl<'a> Transport<'a> for FileTransport {
             message_id,
             message: email.message_to_string().await?.as_bytes().to_vec(),
         })?;
+
+        #[cfg(feature="runtime-tokio")]
+        use tokio::io::AsyncWriteExt;
 
         File::create(file)
             .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
     clippy::option_unwrap_used
 )]
 
+mod runtime;
 pub mod error;
 #[cfg(feature = "file-transport")]
 pub mod file;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,63 @@
+#[cfg(feature="runtime-async-std")]
+pub use async_std::{
+    future::{ timeout, TimeoutError },
+    fs::File,
+    io::BufRead,
+    io::prelude::BufReadExt,
+    io::BufReader,
+    io::timeout as io_timeout,
+    net::ToSocketAddrs,
+    net::TcpStream
+};
+#[cfg(feature="runtime-tokio")]
+pub use tokio::{
+    fs::File,
+    io::BufReader,
+    io::AsyncBufRead as BufRead,
+    io::AsyncBufReadExt as BufReadExt,
+    net::ToSocketAddrs,
+    net::TcpStream,
+    time::{ timeout, Elapsed as TimeoutError }
+};
+
+pub use futures::io::{
+    Cursor,
+    AsyncRead as Read,
+    AsyncWrite as Write,
+    AsyncReadExt,
+    AsyncWriteExt
+};
+
+#[cfg(feature="runtime-tokio")]
+use std::{
+    io::Result as IoResult,
+    io::{ Error as IoError, ErrorKind },
+    time::Duration,
+    future::Future
+};
+
+/// A shim to match the signature of async-std's io_timeout
+#[cfg(feature="runtime-tokio")]
+pub async fn io_timeout<F,T>(dur: Duration, f: F) -> IoResult<T>
+where F: Future<Output = IoResult<T>> {
+    match timeout(dur, f).await {
+        Ok(r) => r,
+        Err(e) => Err(IoError::new(ErrorKind::TimedOut, e))
+    }
+}
+
+#[cfg(feature="runtime-tokio")]
+pub async fn spawn_blocking<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static {
+    tokio::task::spawn_blocking(f).await.unwrap()
+}
+
+#[cfg(feature="runtime-async-std")]
+pub async fn spawn_blocking<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static {
+    async_std::task::spawn_blocking(f).await
+}

--- a/src/sendmail/error.rs
+++ b/src/sendmail/error.rs
@@ -1,8 +1,7 @@
 //! Error and result type for sendmail transport
 
+use std::io::Error as IoError;
 use std::string::FromUtf8Error;
-
-use async_std::io;
 
 /// An enum of all error kinds.
 #[derive(thiserror::Error, Debug)]
@@ -15,7 +14,7 @@ pub enum Error {
     Utf8Parsing(#[from] FromUtf8Error),
     /// IO error
     #[error("io error: {0}")]
-    Io(#[from] io::Error),
+    Io(#[from] IoError),
 }
 
 /// sendmail result type

--- a/src/sendmail/mod.rs
+++ b/src/sendmail/mod.rs
@@ -4,9 +4,10 @@
 use crate::sendmail::error::SendmailResult;
 use crate::SendableEmail;
 use crate::Transport;
+use crate::runtime::spawn_blocking;
 
-use async_std::prelude::*;
 use async_trait::async_trait;
+use futures::io::AsyncReadExt;
 use log::info;
 use std::convert::AsRef;
 use std::io::prelude::*;
@@ -60,7 +61,7 @@ impl<'a> Transport<'a> for SendmailTransport {
         let _ = email.message().read_to_string(&mut message_content).await;
 
         // TODO: Convert to real async, once async-std has a process implementation.
-        let output = async_std::task::spawn_blocking(move || {
+        let output = spawn_blocking(move || {
             // Spawn the sendmail command
             let mut process = Command::new(command)
                 .arg("-i")

--- a/src/smtp/client/codec.rs
+++ b/src/smtp/client/codec.rs
@@ -1,5 +1,6 @@
-use async_std::io::{self, Write};
-use async_std::prelude::*;
+use std::io;
+
+use crate::runtime::{ Write, AsyncWriteExt };
 
 /// The codec used for transparency
 #[derive(Default, Clone, Copy, Debug)]

--- a/src/smtp/client/mock.rs
+++ b/src/smtp/client/mock.rs
@@ -1,9 +1,12 @@
 #![allow(missing_docs)]
 
-use async_std::io::{self, Cursor, Read, Write};
-use async_std::pin::Pin;
-use async_std::task::{Context, Poll};
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use pin_project::pin_project;
+
+use crate::runtime::{ Cursor, Read, Write };
 
 pub type MockCursor = Cursor<Vec<u8>>;
 

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -1,11 +1,15 @@
 //! Error and result type for SMTP clients
 
-use self::Error::*;
-use crate::smtp::response::{Response, Severity};
-use base64::DecodeError;
-use nom;
 use std::io;
 use std::string::FromUtf8Error;
+
+use base64::DecodeError;
+use nom;
+
+use crate::smtp::response::{Response, Severity};
+use crate::runtime::TimeoutError;
+
+use self::Error::*;
 
 /// An enum of all error kinds.
 #[derive(thiserror::Error, Debug)]
@@ -45,7 +49,7 @@ pub enum Error {
     #[error("parsing: {0:?}")]
     Parsing(nom::error::ErrorKind),
     #[error("timeout: {0}")]
-    Timeout(#[from] async_std::future::TimeoutError),
+    Timeout(#[from] TimeoutError),
     #[error("no stream")]
     NoStream,
     #[error("no server info")]

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -1,11 +1,12 @@
+use std::pin::Pin;
 use std::time::Duration;
+use std::net::SocketAddr;
 
-use async_std::net::{SocketAddr, ToSocketAddrs};
-use async_std::pin::Pin;
 use async_trait::async_trait;
 use log::{debug, info};
 use pin_project::pin_project;
 
+use crate::runtime::ToSocketAddrs;
 use crate::smtp::authentication::{
     Credentials, Mechanism, DEFAULT_ENCRYPTED_MECHANISMS, DEFAULT_UNENCRYPTED_MECHANISMS,
 };


### PR DESCRIPTION
Hello!

Addressing #13 I started work on adding feature flags for each runtime and fixing the various issues that cropped up (many!). I haven't finished the work but I'd like to share what I've done incase somebody else has time to pick up the remaining work needed here, as I am short on time at the moment!

So far, I've added a `runtime-async-std` and `runtime-tokio` feature flag.

```
cargo check --features runtime-async-std
```

Runs without any issues.

```
cargo check --features runtime-tokio
```

Has a few errors remaining that need fixing (primarily around AsyncRead/AsyncWrite traits IIRC).

I've tried to keep all differences contained within `runtime.rs`, though there is one place where I use a `#[cfg(feature="runtime-tokio")]` outside that file at the moment. It would be nice if possible (IMO) to keep all differences contained within `runtime.rs`. I also haven't tweaked or added any specific tests for this (but `cargo test` still works fine with the async-std runtime).

A breaking change I've made is to require selection of the runtime feature; it would be pretty easy to default to async-std though if preferred (this prob breaks the CI stuff that I haven't looked at).

Anyway; please reply if you have an interest on pushing this over the finish line :)

