### PR TITLE
feat: Client connect to SOCKS5 stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ hostname = { version = "0.1.5", optional = true }
 serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
+fast-socks5 = { version = "0.3.1", optional = true }
 fast_chemail = "^0.9"
-fast-socks5 = "0.3.1"
 async-native-tls = "0.3.1"
 async-std = { version = "1.4", features = ["unstable"] }
 async-trait = "0.1.17"
@@ -53,6 +53,7 @@ file-transport = ["serde-impls", "serde_json"]
 smtp-transport = ["bufstream", "base64", "nom", "hostname"]
 sendmail-transport = []
 native-tls-vendored = ["async-native-tls/vendored"]
+socks5 = ["fast-socks5"]
 
 [[example]]
 name = "smtp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
 fast_chemail = "^0.9"
+fast-socks5 = "0.3.1"
 async-native-tls = "0.3.1"
 async-std = { version = "1.4", features = ["unstable"] }
 async-trait = "0.1.17"

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -135,7 +135,6 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
         Ok(())
     }
 
-
     /// Checks if the underlying server socket is connected
     pub fn is_connected(&self) -> bool {
         self.stream.is_some()

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -110,11 +110,6 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
         timeout: Option<Duration>,
         tls_parameters: Option<&ClientTlsParameters>,
     ) -> Result<(), Error> {
-        // Connect should not be called when the client is already connected
-        if self.stream.is_some() {
-            return_err!("The connection is already established", self);
-        }
-
         let mut addresses = addr.to_socket_addrs().await?;
 
         let server_addr = match addresses.next() {
@@ -122,12 +117,24 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
             None => return_err!("Could not resolve hostname", self),
         };
 
-        debug!("connecting to {}", server_addr);
+        self.connect_with_stream(Connector::connect(&server_addr, timeout, tls_parameters).await?).await
+    }
+
+    /// Connects to a pre-defined stream
+    pub async fn connect_with_stream(
+        &mut self,
+        stream: S
+    ) -> Result<(), Error> {
+        // Connect should not be called when the client is already connected
+        if self.stream.is_some() {
+            return_err!("The connection is already established", self);
+        }
 
         // Try to connect
-        self.set_stream(Connector::connect(&server_addr, timeout, tls_parameters).await?);
+        self.set_stream(stream);
         Ok(())
     }
+
 
     /// Checks if the underlying server socket is connected
     pub fn is_connected(&self) -> bool {

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -9,6 +9,7 @@ use async_std::net::{Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4, TcpStream};
 use async_std::pin::Pin;
 use async_std::task::{Context, Poll};
 use async_trait::async_trait;
+#[cfg(feature = "socks5")]
 use fast_socks5::client::Socks5Stream;
 use pin_project::{pin_project, project};
 
@@ -47,6 +48,7 @@ pub enum NetworkStream {
     /// Encrypted TCP stream
     Tls(#[pin] TlsStream<TcpStream>),
     /// Socks5 stream
+    #[cfg(feature = "socks5")]
     Socks5Stream(#[pin] Socks5Stream<TcpStream>),
     /// Mock stream
     Mock(#[pin] MockStream),
@@ -58,6 +60,7 @@ impl NetworkStream {
         match *self {
             NetworkStream::Tcp(ref s) => s.peer_addr(),
             NetworkStream::Tls(ref s) => s.get_ref().peer_addr(),
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(ref s) => s.get_socket_ref().peer_addr(),
             NetworkStream::Mock(_) => Ok(SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::new(127, 0, 0, 1),
@@ -71,6 +74,7 @@ impl NetworkStream {
         match *self {
             NetworkStream::Tcp(ref s) => s.shutdown(how),
             NetworkStream::Tls(ref s) => s.get_ref().shutdown(how),
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(ref s) => s.get_socket_ref().shutdown(how),
             NetworkStream::Mock(_) => Ok(()),
         }
@@ -94,6 +98,7 @@ impl Read for NetworkStream {
                 let _: Pin<&mut TlsStream<TcpStream>> = s;
                 s.poll_read(cx, buf)
             }
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(s) => {
                 let _: Pin<&mut Socks5Stream<TcpStream>> = s;
                 s.poll_read(cx, buf)
@@ -119,6 +124,7 @@ impl Write for NetworkStream {
                 let _: Pin<&mut TlsStream<TcpStream>> = s;
                 s.poll_write(cx, buf)
             }
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(s) => {
                 s.poll_write(cx, buf)
             }
@@ -141,6 +147,7 @@ impl Write for NetworkStream {
                 let _: Pin<&mut TlsStream<TcpStream>> = s;
                 s.poll_flush(cx)
             }
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(s) => {
                 s.poll_flush(cx)
             }
@@ -163,6 +170,7 @@ impl Write for NetworkStream {
                 let _: Pin<&mut TlsStream<TcpStream>> = s;
                 s.poll_close(cx)
             }
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(s) => {
                 s.poll_close(cx)
             }
@@ -242,6 +250,7 @@ impl Connector for NetworkStream {
         match *self {
             NetworkStream::Tcp(_) => false,
             NetworkStream::Tls(_) => true,
+            #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(_) => false,
             NetworkStream::Mock(_) => false,
         }


### PR DESCRIPTION
This may be a long shot. In my project, I need to connect to a SMTP server via a SOCKS5 proxy. This PR adds this possibility.

I know that this might be adding maintenance for you, esp now with one new dependency (`fast-socks5`). If you close this PR, I totally understand, and I will just fork it and use my own fork.

Note: an idea to remove the fast-socks5 dep: Make `NetworkStream` a trait? It'll have `Connector`, `fn shutdown()`, `fn peer_addr()` etc.