### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ fast_chemail = "^0.9"
 async-native-tls = { version = "0.3.3" }
 async-std = { version = "1.6.0", features = ["unstable"] }
 async-trait = "0.1.17"
-pin-project = "0.4.5"
+pin-project = "0.4.17"
 pin-utils = "0.1.0-alpha.4"
 thiserror = "1.0.9"
 


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*