### PR TITLE
Use connect and send in examples and remove some warnings

### DIFF
--- a/examples/smtp.rs
+++ b/examples/smtp.rs
@@ -1,4 +1,4 @@
-use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient, Transport};
+use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient};
 
 fn main() {
     env_logger::init();

--- a/examples/smtp.rs
+++ b/examples/smtp.rs
@@ -19,7 +19,7 @@ fn main() {
             .unwrap()
             .into_transport();
         // Send the email
-        let result = mailer.send(email).await;
+        let result = mailer.connect_and_send(email).await;
 
         if result.is_ok() {
             println!("Email sent");

--- a/examples/smtp_gmail.rs
+++ b/examples/smtp_gmail.rs
@@ -1,5 +1,5 @@
 use async_smtp::smtp::authentication::Credentials;
-use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient, Transport};
+use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient};
 
 fn main() {
     async_std::task::block_on(async move {

--- a/examples/smtp_gmail.rs
+++ b/examples/smtp_gmail.rs
@@ -26,7 +26,7 @@ fn main() {
             .into_transport();
 
         // Send the email
-        let result = mailer.send(email).await;
+        let result = mailer.connect_and_send(email).await;
 
         if result.is_ok() {
             println!("Email sent");

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -411,7 +411,7 @@ impl<'a> SmtpTransport {
 
                 let client = std::mem::replace(&mut self.client, InnerClient::default());
                 let ssl_client = client.upgrade_tls_stream(tls_parameters).await?;
-                std::mem::replace(&mut self.client, ssl_client);
+                self.client = ssl_client;
 
                 debug!("connection encrypted");
 


### PR DESCRIPTION
Hi,

Thanks for this library!

I had some trouble using it, by only looking at the examples because they use `send` without
connecting.

I replaced it with `connect_and_send` in the examples (also suggested in #15).

I also removed two unused imports in the exmaples and handled one warning.

All the best,
bold