### PR TITLE
Do not expose the hostname to the server, just make it localhost

### DIFF
--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -108,7 +108,7 @@ impl SmtpClient {
                 smtp_utf8: false,
                 credentials: None,
                 connection_reuse: ConnectionReuseParameters::NoReuse,
-                hello_name: ClientId::hostname(),
+                hello_name: ClientId::new("localhost".to_string()),
                 authentication_mechanism: None,
                 force_set_auth: false,
                 timeout: Some(Duration::new(60, 0)),


### PR DESCRIPTION
I run the dc python remote tests on this and, no surprise, they ran fine.
Fix https://github.com/async-email/async-smtp/issues/25 fix https://github.com/deltachat/deltachat-core-rust/issues/1728