### PR TITLE
"Flexible timeouts" followup

### DIFF
--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -207,13 +207,8 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
         command: C,
         timeout: Option<&Duration>,
     ) -> SmtpResult {
-        with_timeout(timeout, async {
-            self.as_mut().write(command.to_string().as_bytes()).await?;
-            let res = self.read_response_no_timeout().await?;
-
-            Ok(res)
-        })
-        .await
+        with_timeout(timeout, self.as_mut().write(command.to_string().as_bytes())).await?;
+        with_timeout(timeout, self.read_response_no_timeout()).await
     }
 
     /// Writes the given data to the server.

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -552,7 +552,10 @@ impl<'a> Transport<'a> for SmtpTransport {
         // Data
         try_smtp!(client.as_mut().command(DataCommand).await, self);
 
-        let res = client.as_mut().message(email.message()).await;
+        let res = client
+            .as_mut()
+            .message_with_timeout(email.message(), timeout)
+            .await;
 
         // Message content
         if let Ok(result) = &res {


### PR DESCRIPTION
A follow-up for #26 

Two commits.

The first one splits timeouts for command writing and response reading, which I think is more robust, because timeout is effectively restarted after successful write operation.

The second one hopefully fixes https://github.com/deltachat/deltachat-core-rust/issues/1383 for real. Previously custom timeout was applied to all operations except the most expensive one: sending the data and waiting for response. Even worse, after #26 the default timeout (30 seconds in delta chat) was applied to reading the message into the buffer, sending the message, and waiting for response. As a result, sometimes after writing the whole file, 30 seconds were already elapsed, and QUIT was sent immediately after the message instead of waiting for response. Now I have applied the correct timeout and split writing and reading timeouts, like in the first commit.

Commit messages explain the same thing, but without references to delta chat issues and github PRs.