### PR TITLE
Use address literal as default EHLO argument

### DIFF
--- a/src/smtp/commands.rs
+++ b/src/smtp/commands.rs
@@ -335,6 +335,7 @@ mod test {
     #[test]
     fn test_display() {
         let id = ClientId::Domain("localhost".to_string());
+        let id_ipv4 = ClientId::Ipv4(std::net::Ipv4Addr::new(127, 0, 0, 1));
         let email = EmailAddress::new("test@example.com".to_string()).unwrap();
         let mail_parameter = MailParameter::Other {
             keyword: "TEST".to_string(),
@@ -345,6 +346,10 @@ mod test {
             value: Some("value".to_string()),
         };
         assert_eq!(format!("{}", EhloCommand::new(id)), "EHLO localhost\r\n");
+        assert_eq!(
+            format!("{}", EhloCommand::new(id_ipv4)),
+            "EHLO [127.0.0.1]\r\n"
+        );
         assert_eq!(
             format!("{}", MailCommand::new(Some(email.clone()), vec![])),
             "MAIL FROM:<test@example.com>\r\n"

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -108,7 +108,7 @@ impl SmtpClient {
                 smtp_utf8: false,
                 credentials: None,
                 connection_reuse: ConnectionReuseParameters::NoReuse,
-                hello_name: ClientId::new("localhost".to_string()),
+                hello_name: Default::default(),
                 authentication_mechanism: None,
                 force_set_auth: false,
                 timeout: Some(Duration::new(60, 0)),


### PR DESCRIPTION
This commit fixes formatting of IPv4 and IPv6 address literals.
Both are enclosed in brackets and IPv6 is prefixed with `IPv6:`.

Default trait is derived for ClientId.

Default ClientId is `[127.0.0.1]` now, because it passes the most strict
Postfix `smtpd_helo_restrictions` checks.

Fallback domain ClientId is replaced with `localhost.localdomain`,
because a domain must be an FQDN according to RFC 5321.