### PR TITLE
Stop parsing sendmail arguments before addresses

### DIFF
--- a/src/sendmail/mod.rs
+++ b/src/sendmail/mod.rs
@@ -69,6 +69,7 @@ impl<'a> Transport<'a> for SendmailTransport {
                 .arg("-i")
                 .arg("-f")
                 .arg(from)
+                .arg("--")
                 .args(to)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
Upstream fix https://github.com/lettre/lettre/pull/508/commits/bbe7cc5381c5380b54fb8bbb4f77a3725917ff0b
Security advisory: https://github.com/RustSec/advisory-db/blob/master/crates/lettre/RUSTSEC-2020-0069.md