### PR TITLE
Improve socks5 api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ env_logger = "^0.8"
 glob = "^0.3"
 criterion = "^0.3"
 async-attributes = "1.1.1"
+anyhow = "1.0.40"
 
 [[bench]]
 name = "transport_smtp"
@@ -61,3 +62,7 @@ required-features = ["smtp-transport"]
 [[example]]
 name = "smtp_gmail"
 required-features = ["smtp-transport"]
+
+[[example]]
+name = "socks5"
+required-features = ["smtp-transport", "socks5"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ env_logger = "^0.8"
 glob = "^0.3"
 criterion = "^0.3"
 async-attributes = "1.1.1"
-anyhow = "1.0.40"
 
 [[bench]]
 name = "transport_smtp"

--- a/benches/transport_smtp.rs
+++ b/benches/transport_smtp.rs
@@ -1,4 +1,7 @@
-use async_smtp::{ClientSecurity, EmailAddress, Envelope, SendableEmail, ServerAddress, SmtpClient, Transport, smtp::ConnectionReuseParameters};
+use async_smtp::{
+    smtp::ConnectionReuseParameters, ClientSecurity, EmailAddress, Envelope, SendableEmail,
+    ServerAddress, SmtpClient, Transport,
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 const SERVER_ADDR: &str = "127.0.0.1";
@@ -6,7 +9,10 @@ const SERVER_PORT: u16 = 2525;
 
 fn bench_simple_send(c: &mut Criterion) {
     let mut sender = async_std::task::block_on(async move {
-        SmtpClient::with_security(ServerAddress::new(SERVER_ADDR.to_string(), SERVER_PORT), ClientSecurity::None)
+        SmtpClient::with_security(
+            ServerAddress::new(SERVER_ADDR.to_string(), SERVER_PORT),
+            ClientSecurity::None,
+        )
     })
     .into_transport();
 
@@ -34,7 +40,10 @@ fn bench_simple_send(c: &mut Criterion) {
 
 fn bench_reuse_send(c: &mut Criterion) {
     let mut sender = async_std::task::block_on(async move {
-        SmtpClient::with_security(ServerAddress::new(SERVER_ADDR.to_string(), SERVER_PORT), ClientSecurity::None)
+        SmtpClient::with_security(
+            ServerAddress::new(SERVER_ADDR.to_string(), SERVER_PORT),
+            ClientSecurity::None,
+        )
     })
     .connection_reuse(ConnectionReuseParameters::ReuseUnlimited)
     .into_transport();

--- a/benches/transport_smtp.rs
+++ b/benches/transport_smtp.rs
@@ -1,16 +1,13 @@
-use async_smtp::{
-    smtp::ConnectionReuseParameters, ClientSecurity, EmailAddress, Envelope, SendableEmail,
-    SmtpClient, Transport,
-};
+use async_smtp::{ClientSecurity, EmailAddress, Envelope, SendableEmail, ServerAddress, SmtpClient, Transport, smtp::ConnectionReuseParameters};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-const SERVER: &str = "127.0.0.1:2525";
+const SERVER_ADDR: &str = "127.0.0.1";
+const SERVER_PORT: u16 = 2525;
 
 fn bench_simple_send(c: &mut Criterion) {
     let mut sender = async_std::task::block_on(async move {
-        SmtpClient::with_security(SERVER, ClientSecurity::None).await
+        SmtpClient::with_security(ServerAddress::new(SERVER_ADDR.to_string(), SERVER_PORT), ClientSecurity::None)
     })
-    .unwrap()
     .into_transport();
 
     c.bench_function("send email", move |b| {
@@ -37,9 +34,8 @@ fn bench_simple_send(c: &mut Criterion) {
 
 fn bench_reuse_send(c: &mut Criterion) {
     let mut sender = async_std::task::block_on(async move {
-        SmtpClient::with_security(SERVER, ClientSecurity::None).await
+        SmtpClient::with_security(ServerAddress::new(SERVER_ADDR.to_string(), SERVER_PORT), ClientSecurity::None)
     })
-    .unwrap()
     .connection_reuse(ConnectionReuseParameters::ReuseUnlimited)
     .into_transport();
     c.bench_function("send email with connection reuse", move |b| {

--- a/examples/smtp.rs
+++ b/examples/smtp.rs
@@ -15,8 +15,6 @@ fn main() {
 
         // Open a local connection on port 25
         let mut mailer = SmtpClient::new_unencrypted_localhost()
-            .await
-            .unwrap()
             .into_transport();
         // Send the email
         let result = mailer.connect_and_send(email).await;

--- a/examples/smtp.rs
+++ b/examples/smtp.rs
@@ -14,8 +14,7 @@ fn main() {
         );
 
         // Open a local connection on port 25
-        let mut mailer = SmtpClient::new_unencrypted_localhost()
-            .into_transport();
+        let mut mailer = SmtpClient::new_unencrypted_localhost().into_transport();
         // Send the email
         let result = mailer.connect_and_send(email).await;
 

--- a/examples/smtp_gmail.rs
+++ b/examples/smtp_gmail.rs
@@ -19,9 +19,7 @@ fn main() {
         );
 
         // Open a remote connection to gmail
-        let mut mailer = SmtpClient::new("smtp.gmail.com")
-            .await
-            .unwrap()
+        let mut mailer = SmtpClient::new("smtp.gmail.com".to_string())
             .credentials(creds)
             .into_transport();
 

--- a/examples/socks5.rs
+++ b/examples/socks5.rs
@@ -1,0 +1,42 @@
+use async_smtp::smtp::authentication::Credentials;
+use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient};
+use async_smtp::smtp::Socks5Config;
+use anyhow;
+
+fn main() -> Result<(), anyhow::Error> {
+    env_logger::init();
+    async_std::task::block_on(async move {
+        let creds = Credentials::new("user".to_string(), "pass".to_string());
+        let socks5_config = Socks5Config::new("127.0.0.1".to_string(), 9150);
+        let mut transport  = SmtpClient::new_host_port(
+                "xc7tgk2c5onxni2wsy76jslfsitxjbbptejnqhw6gy2ft7khpevhc7ad.onion".to_string(),
+                25
+            )
+            .use_socks5(socks5_config)
+            .credentials(creds)
+            .into_transport();
+
+        
+        let email = SendableEmail::new(
+            Envelope::new(
+                Some(EmailAddress::new("from@mail2tor.com".to_string()).unwrap()),
+                vec![EmailAddress::new("to@mail2tor.com".to_string()).unwrap()],
+            )
+            .unwrap(),
+            "id".to_string(),
+            "Hello ß☺ example".to_string().into_bytes(),
+        );
+
+        let result = transport.connect_and_send(email).await;
+
+        if result.is_ok() {
+            println!("Email sent");
+        } else {
+            println!("Could not send email: {:?}", result);
+        }
+        
+        assert!(result.is_ok());
+        
+        Ok::<(), anyhow::Error>(())
+    })
+}

--- a/examples/socks5.rs
+++ b/examples/socks5.rs
@@ -1,22 +1,21 @@
-use async_smtp::smtp::authentication::Credentials;
-use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient};
-use async_smtp::smtp::Socks5Config;
 use anyhow;
+use async_smtp::smtp::authentication::Credentials;
+use async_smtp::smtp::Socks5Config;
+use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient};
 
 fn main() -> Result<(), anyhow::Error> {
     env_logger::init();
     async_std::task::block_on(async move {
         let creds = Credentials::new("user".to_string(), "pass".to_string());
         let socks5_config = Socks5Config::new("127.0.0.1".to_string(), 9150);
-        let mut transport  = SmtpClient::new_host_port(
-                "xc7tgk2c5onxni2wsy76jslfsitxjbbptejnqhw6gy2ft7khpevhc7ad.onion".to_string(),
-                25
-            )
-            .use_socks5(socks5_config)
-            .credentials(creds)
-            .into_transport();
+        let mut transport = SmtpClient::new_host_port(
+            "xc7tgk2c5onxni2wsy76jslfsitxjbbptejnqhw6gy2ft7khpevhc7ad.onion".to_string(),
+            25,
+        )
+        .use_socks5(socks5_config)
+        .credentials(creds)
+        .into_transport();
 
-        
         let email = SendableEmail::new(
             Envelope::new(
                 Some(EmailAddress::new("from@mail2tor.com".to_string()).unwrap()),
@@ -34,9 +33,9 @@ fn main() -> Result<(), anyhow::Error> {
         } else {
             println!("Could not send email: {:?}", result);
         }
-        
+
         assert!(result.is_ok());
-        
+
         Ok::<(), anyhow::Error>(())
     })
 }

--- a/examples/socks5.rs
+++ b/examples/socks5.rs
@@ -1,9 +1,8 @@
-use anyhow;
 use async_smtp::smtp::authentication::Credentials;
 use async_smtp::smtp::Socks5Config;
 use async_smtp::{EmailAddress, Envelope, SendableEmail, SmtpClient};
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() {
     env_logger::init();
     async_std::task::block_on(async move {
         let creds = Credentials::new("user".to_string(), "pass".to_string());
@@ -35,7 +34,5 @@ fn main() -> Result<(), anyhow::Error> {
         }
 
         assert!(result.is_ok());
-
-        Ok::<(), anyhow::Error>(())
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::sendmail::SendmailTransport;
 #[cfg(feature = "smtp-transport")]
 pub use crate::smtp::client::net::ClientTlsParameters;
 #[cfg(feature = "smtp-transport")]
-pub use crate::smtp::{ClientSecurity, SmtpClient, SmtpTransport};
+pub use crate::smtp::{ClientSecurity, SmtpClient, SmtpTransport, ServerAddress};
 
 use async_trait::async_trait;
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ pub use crate::smtp::client::net::ClientTlsParameters;
 #[cfg(feature = "smtp-transport")]
 pub use crate::smtp::{ClientSecurity, SmtpClient, SmtpTransport, ServerAddress};
 
+#[cfg(features = "socks5")]
+pub use crate::smtp::SmtpClient::Socks5Config;
+
 use async_trait::async_trait;
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::sendmail::SendmailTransport;
 #[cfg(feature = "smtp-transport")]
 pub use crate::smtp::client::net::ClientTlsParameters;
 #[cfg(feature = "smtp-transport")]
-pub use crate::smtp::{ClientSecurity, SmtpClient, SmtpTransport, ServerAddress};
+pub use crate::smtp::{ClientSecurity, ServerAddress, SmtpClient, SmtpTransport};
 
 #[cfg(features = "socks5")]
 pub use crate::smtp::SmtpClient::Socks5Config;

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -15,6 +15,8 @@ use crate::smtp::client::ClientCodec;
 use crate::smtp::commands::*;
 use crate::smtp::error::{Error, SmtpResult};
 use crate::smtp::response::parse_response;
+use crate::smtp::Socks5Config;
+use crate::ServerAddress;
 
 /// Returns the string replacing all the CRLF with "\<CRLF\>"
 /// Used for debug displays
@@ -121,6 +123,13 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
             .await
     }
 
+    pub async fn connect_socks5(
+        &mut self,
+        socks5: &Socks5Config, addr: &ServerAddress, timeout: Option<Duration>, tls_parameters: Option<&ClientTlsParameters>
+    ) -> Result<(), Error> {
+        self.connect_with_stream(Connector::connect_socks5(socks5, addr, timeout, tls_parameters).await?)
+            .await
+    }
     /// Connects to a pre-defined stream
     pub async fn connect_with_stream(&mut self, stream: S) -> Result<(), Error> {
         // Connect should not be called when the client is already connected

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -15,6 +15,8 @@ use crate::smtp::client::ClientCodec;
 use crate::smtp::commands::*;
 use crate::smtp::error::{Error, SmtpResult};
 use crate::smtp::response::parse_response;
+
+#[cfg(feature = "socks5")]
 use crate::smtp::Socks5Config;
 use crate::ServerAddress;
 
@@ -123,6 +125,8 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
             .await
     }
 
+
+    #[cfg(feature = "socks5")]
     pub async fn connect_socks5(
         &mut self,
         socks5: &Socks5Config,

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -124,7 +124,6 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
             .await
     }
 
-
     #[cfg(feature = "socks5")]
     pub async fn connect_socks5(
         &mut self,

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -18,6 +18,8 @@ use crate::smtp::response::parse_response;
 
 #[cfg(feature = "socks5")]
 use crate::smtp::Socks5Config;
+#[cfg(feature = "socks5")]
+use crate::ServerAddress;
 
 /// Returns the string replacing all the CRLF with "\<CRLF\>"
 /// Used for debug displays

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -18,7 +18,6 @@ use crate::smtp::response::parse_response;
 
 #[cfg(feature = "socks5")]
 use crate::smtp::Socks5Config;
-use crate::ServerAddress;
 
 /// Returns the string replacing all the CRLF with "\<CRLF\>"
 /// Used for debug displays

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -125,10 +125,15 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
 
     pub async fn connect_socks5(
         &mut self,
-        socks5: &Socks5Config, addr: &ServerAddress, timeout: Option<Duration>, tls_parameters: Option<&ClientTlsParameters>
+        socks5: &Socks5Config,
+        addr: &ServerAddress,
+        timeout: Option<Duration>,
+        tls_parameters: Option<&ClientTlsParameters>,
     ) -> Result<(), Error> {
-        self.connect_with_stream(Connector::connect_socks5(socks5, addr, timeout, tls_parameters).await?)
-            .await
+        self.connect_with_stream(
+            Connector::connect_socks5(socks5, addr, timeout, tls_parameters).await?,
+        )
+        .await
     }
     /// Connects to a pre-defined stream
     pub async fn connect_with_stream(&mut self, stream: S) -> Result<(), Error> {

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -254,7 +254,6 @@ impl Connector for NetworkStream {
         }
     }
 
-
     #[cfg(feature = "socks5")]
     async fn connect_socks5(
         socks5: &Socks5Config,

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -17,6 +17,8 @@ use crate::smtp::client::mock::MockStream;
 
 #[cfg(feature = "socks5")]
 use crate::smtp::Socks5Config;
+#[cfg(feature = "socks5")]
+use crate::ServerAddress;
 
 /// Parameters to use for secure clients
 pub struct ClientTlsParameters {

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -17,7 +17,6 @@ use crate::smtp::client::mock::MockStream;
 
 #[cfg(feature = "socks5")]
 use crate::smtp::Socks5Config;
-use crate::ServerAddress;
 
 /// Parameters to use for secure clients
 pub struct ClientTlsParameters {

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -13,7 +13,10 @@ use async_trait::async_trait;
 use fast_socks5::client::Socks5Stream;
 use pin_project::pin_project;
 
+use crate::ServerAddress;
 use crate::smtp::client::mock::MockStream;
+use crate::smtp::Socks5Config;
+
 
 /// Parameters to use for secure clients
 pub struct ClientTlsParameters {
@@ -50,6 +53,8 @@ pub enum NetworkStream {
     /// Socks5 stream
     #[cfg(feature = "socks5")]
     Socks5Stream(#[pin] Socks5Stream<TcpStream>),
+    #[cfg(feature = "socks5")]
+    TlsSocks5Stream(#[pin] TlsStream<Socks5Stream<TcpStream>>),
     /// Mock stream
     Mock(#[pin] MockStream),
 }
@@ -62,10 +67,13 @@ impl NetworkStream {
             NetworkStream::Tls(ref s) => s.get_ref().peer_addr(),
             #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(ref s) => s.get_socket_ref().peer_addr(),
+            #[cfg(feature = "socks5")]
+            NetworkStream::TlsSocks5Stream(ref s) => s.get_ref().get_socket_ref().peer_addr(),
             NetworkStream::Mock(_) => Ok(SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::new(127, 0, 0, 1),
                 80,
             ))),
+
         }
     }
 
@@ -76,6 +84,8 @@ impl NetworkStream {
             NetworkStream::Tls(ref s) => s.get_ref().shutdown(how),
             #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(ref s) => s.get_socket_ref().shutdown(how),
+            #[cfg(feature = "socks5")]
+            NetworkStream::TlsSocks5Stream(ref s) => s.get_ref().get_socket_ref().shutdown(how),
             NetworkStream::Mock(_) => Ok(()),
         }
     }
@@ -101,6 +111,11 @@ impl Read for NetworkStream {
                 let _: Pin<&mut Socks5Stream<TcpStream>> = s;
                 s.poll_read(cx, buf)
             }
+            #[cfg(feature = "socks5")]
+            NetworkStreamProj::TlsSocks5Stream(s) => {
+                let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
+                s.poll_read(cx, buf)
+            }
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_read(cx, buf)
@@ -122,6 +137,11 @@ impl Write for NetworkStream {
             }
             #[cfg(feature = "socks5")]
             NetworkStreamProj::Socks5Stream(s) => s.poll_write(cx, buf),
+            #[cfg(feature = "socks5")]
+            NetworkStreamProj::TlsSocks5Stream(s) => {
+                let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
+                s.poll_write(cx, buf)
+            },
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_write(cx, buf)
@@ -141,6 +161,11 @@ impl Write for NetworkStream {
             }
             #[cfg(feature = "socks5")]
             NetworkStreamProj::Socks5Stream(s) => s.poll_flush(cx),
+            #[cfg(feature = "socks5")]
+            NetworkStreamProj::TlsSocks5Stream(s) => {
+                let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
+                s.poll_flush(cx)
+            },
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_flush(cx)
@@ -160,6 +185,11 @@ impl Write for NetworkStream {
             }
             #[cfg(feature = "socks5")]
             NetworkStreamProj::Socks5Stream(s) => s.poll_close(cx),
+            #[cfg(feature = "socks5")]
+            NetworkStreamProj::TlsSocks5Stream(s) => {
+                let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
+                s.poll_close(cx)
+            },
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_close(cx)
@@ -177,6 +207,12 @@ pub trait Connector: Sized {
         timeout: Option<Duration>,
         tls_parameters: Option<&ClientTlsParameters>,
     ) -> io::Result<Self>;
+    async fn connect_socks5(
+        socks5: &Socks5Config,
+        addr: &ServerAddress,
+        timeout: Option<Duration>,
+        tls_parameters: Option<&ClientTlsParameters>,
+    )-> io::Result<Self>;
     /// Upgrades to TLS connection
     async fn upgrade_tls(self, tls_parameters: &ClientTlsParameters) -> io::Result<Self>;
 
@@ -217,6 +253,38 @@ impl Connector for NetworkStream {
         }
     }
 
+    async fn connect_socks5(
+        socks5: &Socks5Config,
+        addr: &ServerAddress,
+        timeout: Option<Duration>,
+        tls_parameters: Option<&ClientTlsParameters>,
+    )-> io::Result<NetworkStream> {
+        
+        let socks5_stream = socks5
+                    .connect(addr, timeout)
+                    .await?;
+        
+        match tls_parameters {
+            Some(context) => match timeout {
+                Some(duration) => async_std::future::timeout(
+                    duration,
+                    context.connector.connect(&context.domain, socks5_stream),
+                )
+                .await
+                .map_err(|e| io::Error::new(ErrorKind::TimedOut, e))?
+                .map(NetworkStream::TlsSocks5Stream)
+                .map_err(|e| io::Error::new(ErrorKind::Other, e)),
+                None => context
+                    .connector
+                    .connect(&context.domain, socks5_stream)
+                    .await
+                    .map(NetworkStream::TlsSocks5Stream)
+                    .map_err(|e| io::Error::new(ErrorKind::Other, e)),
+            },
+            None => Ok(NetworkStream::Socks5Stream(socks5_stream)),
+        }
+    }
+
     async fn upgrade_tls(self, tls_parameters: &ClientTlsParameters) -> io::Result<Self> {
         match self {
             NetworkStream::Tcp(stream) => {
@@ -238,6 +306,7 @@ impl Connector for NetworkStream {
             NetworkStream::Tls(_) => true,
             #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(_) => false,
+            NetworkStream::TlsSocks5Stream(_) => true,
             NetworkStream::Mock(_) => false,
         }
     }

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -13,10 +13,9 @@ use async_trait::async_trait;
 use fast_socks5::client::Socks5Stream;
 use pin_project::pin_project;
 
-use crate::ServerAddress;
 use crate::smtp::client::mock::MockStream;
 use crate::smtp::Socks5Config;
-
+use crate::ServerAddress;
 
 /// Parameters to use for secure clients
 pub struct ClientTlsParameters {
@@ -73,7 +72,6 @@ impl NetworkStream {
                 Ipv4Addr::new(127, 0, 0, 1),
                 80,
             ))),
-
         }
     }
 
@@ -141,7 +139,7 @@ impl Write for NetworkStream {
             NetworkStreamProj::TlsSocks5Stream(s) => {
                 let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
                 s.poll_write(cx, buf)
-            },
+            }
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_write(cx, buf)
@@ -165,7 +163,7 @@ impl Write for NetworkStream {
             NetworkStreamProj::TlsSocks5Stream(s) => {
                 let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
                 s.poll_flush(cx)
-            },
+            }
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_flush(cx)
@@ -189,7 +187,7 @@ impl Write for NetworkStream {
             NetworkStreamProj::TlsSocks5Stream(s) => {
                 let _: Pin<&mut TlsStream<Socks5Stream<TcpStream>>> = s;
                 s.poll_close(cx)
-            },
+            }
             NetworkStreamProj::Mock(s) => {
                 let _: Pin<&mut MockStream> = s;
                 s.poll_close(cx)
@@ -212,7 +210,7 @@ pub trait Connector: Sized {
         addr: &ServerAddress,
         timeout: Option<Duration>,
         tls_parameters: Option<&ClientTlsParameters>,
-    )-> io::Result<Self>;
+    ) -> io::Result<Self>;
     /// Upgrades to TLS connection
     async fn upgrade_tls(self, tls_parameters: &ClientTlsParameters) -> io::Result<Self>;
 
@@ -258,12 +256,9 @@ impl Connector for NetworkStream {
         addr: &ServerAddress,
         timeout: Option<Duration>,
         tls_parameters: Option<&ClientTlsParameters>,
-    )-> io::Result<NetworkStream> {
-        
-        let socks5_stream = socks5
-                    .connect(addr, timeout)
-                    .await?;
-        
+    ) -> io::Result<NetworkStream> {
+        let socks5_stream = socks5.connect(addr, timeout).await?;
+
         match tls_parameters {
             Some(context) => match timeout {
                 Some(duration) => async_std::future::timeout(

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -14,6 +14,8 @@ use fast_socks5::client::Socks5Stream;
 use pin_project::pin_project;
 
 use crate::smtp::client::mock::MockStream;
+
+#[cfg(feature = "socks5")]
 use crate::smtp::Socks5Config;
 use crate::ServerAddress;
 
@@ -205,6 +207,8 @@ pub trait Connector: Sized {
         timeout: Option<Duration>,
         tls_parameters: Option<&ClientTlsParameters>,
     ) -> io::Result<Self>;
+
+    #[cfg(feature = "socks5")]
     async fn connect_socks5(
         socks5: &Socks5Config,
         addr: &ServerAddress,
@@ -251,6 +255,8 @@ impl Connector for NetworkStream {
         }
     }
 
+
+    #[cfg(feature = "socks5")]
     async fn connect_socks5(
         socks5: &Socks5Config,
         addr: &ServerAddress,
@@ -301,6 +307,7 @@ impl Connector for NetworkStream {
             NetworkStream::Tls(_) => true,
             #[cfg(feature = "socks5")]
             NetworkStream::Socks5Stream(_) => false,
+            #[cfg(feature = "socks5")]
             NetworkStream::TlsSocks5Stream(_) => true,
             NetworkStream::Mock(_) => false,
         }

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -39,6 +39,7 @@ impl ClientTlsParameters {
     }
 }
 
+
 /// Represents the different types of underlying network streams
 #[pin_project(project = NetworkStreamProj)]
 #[allow(missing_debug_implementations)]

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -296,7 +296,19 @@ impl Connector for NetworkStream {
                     .map_err(|err| io::Error::new(ErrorKind::Other, err))?;
                 Ok(NetworkStream::Tls(tls_stream))
             }
-            _ => Ok(self),
+            NetworkStream::Tls(_) => Ok(self),
+            #[cfg(feature = "socks5")]
+            NetworkStream::Socks5Stream(stream) => {
+                let tls_stream = tls_parameters
+                    .connector
+                    .connect(&tls_parameters.domain, stream)
+                    .await
+                    .map_err(|err| io::Error::new(ErrorKind::Other, err))?;
+                Ok(NetworkStream::TlsSocks5Stream(tls_stream))
+            }
+            #[cfg(feature = "socks5")]
+            NetworkStream::TlsSocks5Stream(_) => Ok(self),
+            NetworkStream::Mock(_) => Ok(self),
         }
     }
 

--- a/src/smtp/client/net.rs
+++ b/src/smtp/client/net.rs
@@ -39,7 +39,6 @@ impl ClientTlsParameters {
     }
 }
 
-
 /// Represents the different types of underlying network streams
 #[pin_project(project = NetworkStreamProj)]
 #[allow(missing_debug_implementations)]

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -4,6 +4,7 @@ use self::Error::*;
 use crate::smtp::response::{Response, Severity};
 use base64::DecodeError;
 use std::io;
+use std::net::AddrParseError;
 use std::string::FromUtf8Error;
 
 
@@ -53,10 +54,14 @@ pub enum Error {
     NoStream,
     #[error("no server info")]
     NoServerInfo,
+    
+    #[error("address parse error")]
+    AddrParseError(#[from] AddrParseError),
 
     #[cfg(feature = "socks5")]
     #[error("socks5 error")]
     SocksError( #[from] fast_socks5::SocksError),
+    
 }
 
 impl From<nom::Err<(&str, nom::error::ErrorKind)>> for Error {

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
     AddrParseError(#[from] AddrParseError),
 
     #[cfg(feature = "socks5")]
-    #[error("socks5 error")]
+    #[error("socks5 error {0}")]
     Socks5Error(#[from] fast_socks5::SocksError),
 }
 

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
     AddrParseError(#[from] AddrParseError),
 
     #[cfg(feature = "socks5")]
-    #[error("socks5 error {0}")]
+    #[error("socks5 error: {0}")]
     Socks5Error(#[from] fast_socks5::SocksError),
 }
 

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -7,7 +7,6 @@ use std::io;
 use std::net::AddrParseError;
 use std::string::FromUtf8Error;
 
-
 #[cfg(feature = "socks5")]
 use fast_socks5;
 
@@ -54,14 +53,13 @@ pub enum Error {
     NoStream,
     #[error("no server info")]
     NoServerInfo,
-    
+
     #[error("address parse error")]
     AddrParseError(#[from] AddrParseError),
 
     #[cfg(feature = "socks5")]
     #[error("socks5 error")]
-    SocksError( #[from] fast_socks5::SocksError),
-    
+    SocksError(#[from] fast_socks5::SocksError),
 }
 
 impl From<nom::Err<(&str, nom::error::ErrorKind)>> for Error {

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
     #[error("no server info")]
     NoServerInfo,
 
-    #[error("address parse error")]
+    #[error("address parse error: {0}")]
     AddrParseError(#[from] AddrParseError),
 
     #[cfg(feature = "socks5")]

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -6,6 +6,10 @@ use base64::DecodeError;
 use std::io;
 use std::string::FromUtf8Error;
 
+
+#[cfg(feature = "socks5")]
+use fast_socks5;
+
 /// An enum of all error kinds.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -49,6 +53,10 @@ pub enum Error {
     NoStream,
     #[error("no server info")]
     NoServerInfo,
+
+    #[cfg(feature = "socks5")]
+    #[error("socks5 error")]
+    SocksError( #[from] fast_socks5::SocksError),
 }
 
 impl From<nom::Err<(&str, nom::error::ErrorKind)>> for Error {

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -59,7 +59,7 @@ pub enum Error {
 
     #[cfg(feature = "socks5")]
     #[error("socks5 error")]
-    SocksError(#[from] fast_socks5::SocksError),
+    Socks5Error(#[from] fast_socks5::SocksError),
 }
 
 impl From<nom::Err<(&str, nom::error::ErrorKind)>> for Error {

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -22,3 +22,6 @@ mod smtp_client;
 pub mod util;
 
 pub use smtp_client::*;
+
+#[cfg(feature = "socks5")]
+pub use smtp_client::Socks5Config;

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -101,21 +101,19 @@ impl Socks5Config {
 
         let socks_connection = if let Some((user, password)) = self.user_password.as_ref() {
             match timeout {
-                Some(timeout) => {
-                    async_std::future::timeout(
-                        timeout,
-                        Socks5Stream::connect_with_password(
-                            socks_server,
-                            target_addr.host.clone(),
-                            target_addr.port,
-                            user.into(),
-                            password.into(),
-                            Config::default(),
-                        ),
-                    )
-                    .await
-                    .map_err(|e| io::Error::new(ErrorKind::TimedOut, e))?
-                }
+                Some(timeout) => async_std::future::timeout(
+                    timeout,
+                    Socks5Stream::connect_with_password(
+                        socks_server,
+                        target_addr.host.clone(),
+                        target_addr.port,
+                        user.into(),
+                        password.into(),
+                        Config::default(),
+                    ),
+                )
+                .await
+                .map_err(|e| io::Error::new(ErrorKind::TimedOut, e))?,
                 None => {
                     Socks5Stream::connect_with_password(
                         socks_server,
@@ -130,19 +128,17 @@ impl Socks5Config {
             }
         } else {
             match timeout {
-                Some(timeout) => {
-                    async_std::future::timeout(
-                        timeout,
-                        Socks5Stream::connect(
-                            socks_server,
-                            target_addr.host.clone(),
-                            target_addr.port,
-                            Config::default(),
-                        ),
-                    )
-                    .await
-                    .map_err(|e| io::Error::new(ErrorKind::TimedOut, e))?
-                }
+                Some(timeout) => async_std::future::timeout(
+                    timeout,
+                    Socks5Stream::connect(
+                        socks_server,
+                        target_addr.host.clone(),
+                        target_addr.port,
+                        Config::default(),
+                    ),
+                )
+                .await
+                .map_err(|e| io::Error::new(ErrorKind::TimedOut, e))?,
                 None => {
                     Socks5Stream::connect(
                         socks_server,
@@ -157,7 +153,10 @@ impl Socks5Config {
 
         match socks_connection {
             Ok(socks5_stream) => Ok(socks5_stream),
-            Err(e) => Err(io::Error::new(ErrorKind::ConnectionRefused, Error::Socks5Error(e))),
+            Err(e) => Err(io::Error::new(
+                ErrorKind::ConnectionRefused,
+                Error::Socks5Error(e),
+            )),
         }
     }
 }
@@ -526,11 +525,10 @@ impl<'a> SmtpTransport {
             .await?;
 
         client.set_timeout(self.client_info.timeout);
-        let _response =
-            super::client::with_timeout(self.client_info.timeout.as_ref(), async {
-                client.read_response().await
-            })
-            .await?;
+        let _response = super::client::with_timeout(self.client_info.timeout.as_ref(), async {
+            client.read_response().await
+        })
+        .await?;
 
         self.post_connect().await
     }

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::time::Duration;
 
-use async_std::net::{SocketAddr, ToSocketAddrs};
+use async_std::net::ToSocketAddrs;
 use async_std::pin::Pin;
 use async_trait::async_trait;
 use log::{debug, info};

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -402,6 +402,7 @@ impl<'a> SmtpTransport {
         Ok(())
     }
 
+    /// Try to connect with the configured connection type, if not already connected.
     pub async fn connect(&mut self) -> Result<(), Error> {
         match &self.client_info.connection_type {
             ConnectionType::Direct => self.connect_direct().await,
@@ -422,7 +423,7 @@ impl<'a> SmtpTransport {
         }
     }
 
-    /// Try to connect, if not already connected.
+    /// Try to connect directly, if not already connected.
     pub async fn connect_direct(&mut self) -> Result<(), Error> {
         // Check if the connection is still available
         if (self.state.connection_reuse_count > 0) && (!self.client.is_connected()) {

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -97,7 +97,6 @@ impl Socks5Config {
         timeout: Duration,
     ) -> Result<Socks5Stream<TcpStream>, Error> {
         let socks_server = format!("{}:{}", self.host.clone(), self.port);
-        println!("{}", socks_server);
 
         let socks_connection = if let Some((user, password)) = self.user_password.as_ref() {
             future::timeout(
@@ -409,7 +408,6 @@ impl<'a> SmtpTransport {
 
             #[cfg(feature = "socks5")]
             ConnectionType::Socks5(socks5) => {
-                println!("Trying to connect with socks5...");
                 let socks5_stream = socks5
                     .connect(
                         &self.client_info.server_addr,
@@ -418,7 +416,6 @@ impl<'a> SmtpTransport {
                             .unwrap_or_else(|| Duration::from_millis(100)),
                     )
                     .await?;
-                println!("Connected through socks5");
                 self.connect_with_stream(NetworkStream::Socks5Stream(socks5_stream))
                     .await
             }
@@ -439,8 +436,6 @@ impl<'a> SmtpTransport {
             );
             return Ok(());
         }
-
-        println!("{}", self.client_info.server_addr);
 
         // Perform dns lookup if needed
         let mut addresses = self

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -66,7 +66,6 @@ impl Display for ServerAddress {
     }
 }
 
-
 #[cfg(feature = "socks5")]
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct Socks5Config {
@@ -75,14 +74,13 @@ pub struct Socks5Config {
     pub user_password: Option<(String, String)>,
 }
 
-
 #[cfg(feature = "socks5")]
 impl Socks5Config {
     pub fn new(host: String, port: u16) -> Self {
         Socks5Config {
             host,
             port,
-            user_password: None
+            user_password: None,
         }
     }
 
@@ -90,7 +88,7 @@ impl Socks5Config {
         Socks5Config {
             host,
             port,
-            user_password: Some((user, password))
+            user_password: Some((user, password)),
         }
     }
     pub async fn connect(
@@ -102,30 +100,35 @@ impl Socks5Config {
         println!("{}", socks_server);
 
         let socks_connection = if let Some((user, password)) = self.user_password.as_ref() {
-            future::timeout(timeout, Socks5Stream::connect_with_password(
-                socks_server,
-                target_addr.host.clone(),
-                target_addr.port,
-                user.into(),
-                password.into(),
-                Config::default(),
-            )).await
-        } else {      
-            future::timeout(timeout, Socks5Stream::connect(
-                socks_server,
-                target_addr.host.clone(),
-                target_addr.port,
-                Config::default(),
-            )).await
+            future::timeout(
+                timeout,
+                Socks5Stream::connect_with_password(
+                    socks_server,
+                    target_addr.host.clone(),
+                    target_addr.port,
+                    user.into(),
+                    password.into(),
+                    Config::default(),
+                ),
+            )
+            .await
+        } else {
+            future::timeout(
+                timeout,
+                Socks5Stream::connect(
+                    socks_server,
+                    target_addr.host.clone(),
+                    target_addr.port,
+                    Config::default(),
+                ),
+            )
+            .await
         };
 
         match socks_connection? {
             Ok(socks5_stream) => Ok(socks5_stream),
             Err(e) => Err(Error::Socks5Error(e)),
         }
-        
-    
-
     }
 }
 
@@ -145,9 +148,6 @@ impl Display for Socks5Config {
         )
     }
 }
-
-
-
 
 #[derive(Clone, Debug)]
 #[allow(missing_copy_implementations)]
@@ -443,7 +443,12 @@ impl<'a> SmtpTransport {
         println!("{}", self.client_info.server_addr);
 
         // Perform dns lookup if needed
-        let mut addresses = self.client_info.server_addr.to_string().to_socket_addrs().await?;
+        let mut addresses = self
+            .client_info
+            .server_addr
+            .to_string()
+            .to_socket_addrs()
+            .await?;
 
         match addresses.next() {
             Some(addr) => {

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -16,7 +16,6 @@ use crate::smtp::commands::*;
 use crate::smtp::error::{Error, SmtpResult};
 use crate::smtp::extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo};
 use crate::{SendableEmail, Transport};
-use async_std::io::{self, ErrorKind};
 
 #[cfg(feature = "socks5")]
 use crate::smtp::client::net::NetworkStream;

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -58,12 +58,6 @@ impl ServerAddress {
     pub fn new(host: String, port: u16) -> ServerAddress {
         ServerAddress { host, port }
     }
-    pub fn to_socket_addr(&self) -> Result<SocketAddr, Error> {
-        match format!("{}:{}", self.host, self.port).parse::<SocketAddr>() {
-            Ok(socket_addr) => Ok(socket_addr),
-            Err(e) => Err(Error::AddrParseError(e)),
-        }
-    }
 }
 
 impl Display for ServerAddress {
@@ -446,10 +440,10 @@ impl<'a> SmtpTransport {
             return Ok(());
         }
 
-        let socket_addr = self.client_info.server_addr.to_socket_addr()?;
+        println!("{}", self.client_info.server_addr);
 
         // Perform dns lookup if needed
-        let mut addresses = socket_addr.to_socket_addrs().await?;
+        let mut addresses = self.client_info.server_addr.to_string().to_socket_addrs().await?;
 
         match addresses.next() {
             Some(addr) => {

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -464,7 +464,7 @@ impl<'a> SmtpTransport {
                 let cloned_socks5 = socks5.clone();
                 client
                     .connect_socks5(
-                        cloned_socks5,
+                        &cloned_socks5,
                         &self.client_info.server_addr.clone().to_owned(),
                         self.client_info.timeout,
                         tls_parameters,

--- a/src/smtp/smtp_client.rs
+++ b/src/smtp/smtp_client.rs
@@ -16,11 +16,11 @@ use crate::smtp::commands::*;
 use crate::smtp::error::{Error, SmtpResult};
 use crate::smtp::extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo};
 use crate::{SendableEmail, Transport};
+#[cfg(feature = "socks5")]
+use async_std::io::{self, ErrorKind};
 
 #[cfg(feature = "socks5")]
-use crate::smtp::client::net::NetworkStream;
-#[cfg(feature = "socks5")]
-use async_std::{future, net::TcpStream};
+use async_std::net::TcpStream;
 #[cfg(feature = "socks5")]
 use fast_socks5::client::{Config, Socks5Stream};
 

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[cfg(feature = "smtp-transport")]
 mod test {
-    use async_smtp::{ClientSecurity, Envelope, SendableEmail, SmtpClient};
+    use async_smtp::{ClientSecurity, Envelope, SendableEmail, SmtpClient, ServerAddress};
 
     #[async_attributes::test]
     #[ignore] // ignored as this needs a running server
@@ -20,9 +20,7 @@ mod test {
         );
 
         println!("connecting");
-        let mut transport = SmtpClient::with_security("127.0.0.1:3025", ClientSecurity::None)
-            .await
-            .unwrap()
+        let mut transport = SmtpClient::with_security(ServerAddress { host: "127.0.0.1".to_string(), port: 3025 }, ClientSecurity::None)
             .into_transport();
 
         println!("sending");

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[cfg(feature = "smtp-transport")]
 mod test {
-    use async_smtp::{ClientSecurity, Envelope, SendableEmail, SmtpClient, ServerAddress};
+    use async_smtp::{ClientSecurity, Envelope, SendableEmail, ServerAddress, SmtpClient};
 
     #[async_attributes::test]
     #[ignore] // ignored as this needs a running server
@@ -20,8 +20,14 @@ mod test {
         );
 
         println!("connecting");
-        let mut transport = SmtpClient::with_security(ServerAddress { host: "127.0.0.1".to_string(), port: 3025 }, ClientSecurity::None)
-            .into_transport();
+        let mut transport = SmtpClient::with_security(
+            ServerAddress {
+                host: "127.0.0.1".to_string(),
+                port: 3025,
+            },
+            ClientSecurity::None,
+        )
+        .into_transport();
 
         println!("sending");
         transport.connect_and_send(email).await.unwrap();


### PR DESCRIPTION
- moving dns lookup from SmtpClient to SmtpTransport, this means some api calls are not async anymore
- implement ConnectionType in SmtpClient to distinguish between Direct and Socks5 connection
- Change SmtpTransport.connect to create the socks5 or direct connection
- add example showing how to use socks5 with async-smtp
