### PR TITLE
Implement our own basic email validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
 fast-socks5 = { version = "^0.4", optional = true }
-fast_chemail = "^0.9"
 async-native-tls = { version = "0.3.3" }
 async-std = { version = "1.6.0", features = ["unstable"] }
 async-trait = "0.1.17"


### PR DESCRIPTION
`fast_chemail` crate is not maintained and is too restrictive: it does
not accept domains without a dot.

Also validate email even if it ends in "localhost" to make sure email
address does not contain control character that can be injected into
SMTP protocol, like "RCPT TO:<foo\r\nQUIT\r\n@localhost>".