### PR TITLE
Bump nom dependency to ^0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ is-it-maintained-open-issues = { repository = "async-email/async-smtp" }
 
 [dependencies]
 log = "^0.4"
-nom = { version = "^5.0", optional = true }
+nom = { version = "^7.0", optional = true }
 bufstream = { version = "^0.1", optional = true }
 base64 = { version = "^0.13", optional = true }
 hostname = { version = "0.3.1", optional = true }

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -282,11 +282,11 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
                     return Err(response.into());
                 }
                 Err(nom::Err::Failure(e)) => {
-                    return Err(Error::Parsing(e.1));
+                    return Err(Error::Parsing(e.code));
                 }
                 Err(nom::Err::Incomplete(_)) => { /* read more */ }
                 Err(nom::Err::Error(e)) => {
-                    return Err(Error::Parsing(e.1));
+                    return Err(Error::Parsing(e.code));
                 }
             }
         }

--- a/src/smtp/commands.rs
+++ b/src/smtp/commands.rs
@@ -11,7 +11,7 @@ use std::convert::AsRef;
 use std::fmt::{self, Display, Formatter};
 
 /// EHLO command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -34,7 +34,7 @@ impl EhloCommand {
 }
 
 /// STARTTLS command
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -48,7 +48,7 @@ impl Display for StarttlsCommand {
 }
 
 /// MAIL command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -80,7 +80,7 @@ impl MailCommand {
 }
 
 /// RCPT command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -111,7 +111,7 @@ impl RcptCommand {
 }
 
 /// DATA command
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -125,7 +125,7 @@ impl Display for DataCommand {
 }
 
 /// QUIT command
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -139,7 +139,7 @@ impl Display for QuitCommand {
 }
 
 /// NOOP command
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -153,7 +153,7 @@ impl Display for NoopCommand {
 }
 
 /// HELP command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -180,7 +180,7 @@ impl HelpCommand {
 }
 
 /// VRFY command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -203,7 +203,7 @@ impl VrfyCommand {
 }
 
 /// EXPN command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -226,7 +226,7 @@ impl ExpnCommand {
 }
 
 /// RSET command
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
@@ -240,7 +240,7 @@ impl Display for RsetCommand {
 }
 
 /// AUTH command
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
     derive(serde_derive::Serialize, serde_derive::Deserialize)

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -62,12 +62,12 @@ pub enum Error {
     Socks5Error(#[from] fast_socks5::SocksError),
 }
 
-impl From<nom::Err<(&str, nom::error::ErrorKind)>> for Error {
-    fn from(err: nom::Err<(&str, nom::error::ErrorKind)>) -> Error {
+impl From<nom::Err<nom::error::Error<&str>>> for Error {
+    fn from(err: nom::Err<nom::error::Error<&str>>) -> Error {
         Parsing(match err {
             nom::Err::Incomplete(_) => nom::error::ErrorKind::Complete,
-            nom::Err::Failure((_, k)) => k,
-            nom::Err::Error((_, k)) => k,
+            nom::Err::Failure(e) => e.code,
+            nom::Err::Error(e) => e.code,
         })
     }
 }

--- a/src/smtp/response.rs
+++ b/src/smtp/response.rs
@@ -253,7 +253,10 @@ pub(crate) fn parse_response(i: &str) -> IResult<&str, Response> {
 
     // Check that all codes are equal.
     if !lines.iter().all(|&(ref code, _, _)| *code == last_code) {
-        return Err(nom::Err::Failure(("", nom::error::ErrorKind::Not)));
+        return Err(nom::Err::Failure(nom::error::Error::new(
+            "",
+            nom::error::ErrorKind::Not,
+        )));
     }
 
     // Extract text from lines, and append last line.


### PR DESCRIPTION
Updating nom to latest version as it's causing build errors in [twistrs](https://github.com/JuxhinDB/twistrs). Tests are passing bar one, however it seems to be related to some missing file/config.

```
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/transport_file.rs (target/debug/deps/transport_file-4c3d8b1858f4d79e)

running 1 test
test test::file_transport ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/transport_sendmail.rs (target/debug/deps/transport_sendmail-35c9ebf37f972ebe)

running 1 test
test test::sendmail_transport_simple ... FAILED

failures:

---- test::sendmail_transport_simple stdout ----
Err(Io(Os { code: 2, kind: NotFound, message: "No such file or directory" }))
thread 'test::sendmail_transport_simple' panicked at 'assertion failed: result.is_ok()', tests/transport_sendmail.rs:22:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```