### PR TITLE
feat: add support for tokoi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ is-it-maintained-open-issues = { repository = "async-email/async-smtp" }
 
 [dependencies]
 log = "^0.4"
-nom = { version = "^5.0", optional = true }
+nom = { version = "^7.0", optional = true }
 bufstream = { version = "^0.1", optional = true }
 base64 = { version = "^0.13", optional = true }
 hostname = { version = "0.3.1", optional = true }
@@ -27,15 +27,15 @@ serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
 fast-socks5 = { version = "^0.4", optional = true }
-async-native-tls = { version = "0.3.3" }
-async-std = { version = "1.6.0", features = ["unstable"] }
+async-native-tls = { version = "0.4" }
+async-std = { version = "1.11", features = ["unstable"] }
 async-trait = "0.1.17"
 pin-project = "1"
 pin-utils = "0.1.0"
 thiserror = "1.0.9"
 
 [dev-dependencies]
-env_logger = "^0.8"
+env_logger = "^0.9"
 glob = "^0.3"
 criterion = "^0.3"
 async-attributes = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,12 @@ is-it-maintained-open-issues = { repository = "async-email/async-smtp" }
 
 [dependencies]
 log = "^0.4"
+async-trait = "0.1.17"
+pin-project = "1"
+pin-utils = "0.1.0"
+thiserror = "1.0.9"
+futures = "0.3.21"
+
 nom = { version = "^7.0", optional = true }
 bufstream = { version = "^0.1", optional = true }
 base64 = { version = "^0.13", optional = true }
@@ -26,33 +32,41 @@ hostname = { version = "0.3.1", optional = true }
 serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
-fast-socks5 = { version = "^0.4", optional = true }
-async-native-tls = { version = "0.4" }
-async-std = { version = "1.11", features = ["unstable"] }
-async-trait = "0.1.17"
-pin-project = "1"
-pin-utils = "0.1.0"
-thiserror = "1.0.9"
+fast-socks5 = { version = "^0.8", optional = true }
+
+async-std = { version = "1.11", features = ["unstable"], optional = true }
+tokio = { version = "1", features = ["fs", "rt", "time", "net"], optional = true }
+async-native-tls = { version = "0.4", default-features = false }
+
 
 [dev-dependencies]
 env_logger = "^0.9"
 glob = "^0.3"
 criterion = "^0.3"
-async-attributes = "1.1.1"
+async-std = { version = "1.11", features = ["unstable", "attributes"] }
+tokio = { version = "1", features = ["fs", "rt", "time", "net", "macros"] }
 
 [[bench]]
 name = "transport_smtp"
 harness = false
 
 [features]
-default = ["file-transport", "smtp-transport", "sendmail-transport"]
-unstable = []
+default = [
+  "file-transport", 
+  "smtp-transport", 
+  "sendmail-transport",
+  "runtime-tokio"
+]
+
 serde-impls = ["serde", "serde_derive"]
 file-transport = ["serde-impls", "serde_json"]
 smtp-transport = ["bufstream", "base64", "nom", "hostname"]
 sendmail-transport = []
 native-tls-vendored = ["async-native-tls/vendored"]
 socks5 = ["fast-socks5"]
+runtime-async-std = ["async-std", "async-native-tls/runtime-async-std"]
+runtime-tokio = ["tokio", "async-native-tls/runtime-tokio"]
+
 
 [[example]]
 name = "smtp"

--- a/src/file/error.rs
+++ b/src/file/error.rs
@@ -1,6 +1,6 @@
 //! Error and result type for file transport
 
-use async_std::io;
+use futures::io;
 
 /// An enum of all error kinds.
 #[derive(thiserror::Error, Debug)]

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -3,12 +3,14 @@
 //! It can be useful for testing purposes, or if you want to keep track of sent messages.
 //!
 
+use std::path::Path;
 use std::{path::PathBuf, time::Duration};
 
-use async_std::fs::File;
-use async_std::path::Path;
-use async_std::prelude::*;
+#[cfg(feature = "runtime-async-std")]
+use async_std::fs::write;
 use async_trait::async_trait;
+#[cfg(feature = "runtime-tokio")]
+use tokio::fs::write;
 
 use crate::file::error::FileResult;
 use crate::Envelope;
@@ -64,10 +66,8 @@ impl<'a> Transport<'a> for FileTransport {
             message: email.message_to_string().await?.as_bytes().to_vec(),
         })?;
 
-        File::create(file)
-            .await?
-            .write_all(serialized.as_bytes())
-            .await?;
+        write(file, serialized.as_bytes()).await?;
+
         Ok(())
     }
 

--- a/src/sendmail/error.rs
+++ b/src/sendmail/error.rs
@@ -2,7 +2,7 @@
 
 use std::string::FromUtf8Error;
 
-use async_std::io;
+use futures::io;
 
 /// An enum of all error kinds.
 #[derive(thiserror::Error, Debug)]
@@ -16,6 +16,9 @@ pub enum Error {
     /// IO error
     #[error("io error: {0}")]
     Io(#[from] io::Error),
+    #[cfg(feature = "runtime-tokio")]
+    #[error("join: {0}")]
+    Join(#[from] tokio::task::JoinError),
 }
 
 /// sendmail result type

--- a/src/smtp/client/codec.rs
+++ b/src/smtp/client/codec.rs
@@ -1,5 +1,9 @@
-use async_std::io::{self, Write};
-use async_std::prelude::*;
+#[cfg(feature = "runtime-async-std")]
+use async_std::io::{Write, WriteExt};
+#[cfg(feature = "runtime-tokio")]
+use tokio::io::{AsyncWrite as Write, AsyncWriteExt};
+
+use futures::io;
 
 /// The codec used for transparency
 #[derive(Default, Clone, Copy, Debug)]

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -1,13 +1,20 @@
 use std::fmt::{Debug, Display};
+use std::net::SocketAddr;
+use std::pin::Pin;
 use std::string::String;
 use std::time::Duration;
 
-use async_std::io::{self, BufReader, Read, Write};
-use async_std::net::ToSocketAddrs;
-use async_std::pin::Pin;
-use async_std::prelude::*;
+use futures::io;
+use futures::prelude::*;
 use log::debug;
 use pin_project::pin_project;
+
+#[cfg(feature = "runtime-async-std")]
+use async_std::io::{BufReader, Read, Write};
+#[cfg(feature = "runtime-tokio")]
+use tokio::io::{
+    AsyncBufReadExt, AsyncRead as Read, AsyncReadExt, AsyncWrite as Write, AsyncWriteExt, BufReader,
+};
 
 use crate::smtp::authentication::{Credentials, Mechanism};
 use crate::smtp::client::net::{ClientTlsParameters, Connector, NetworkStream};
@@ -20,6 +27,11 @@ use crate::smtp::response::parse_response;
 use crate::smtp::Socks5Config;
 #[cfg(feature = "socks5")]
 use crate::ServerAddress;
+
+#[cfg(feature = "runtime-async-std")]
+use async_std::net::ToSocketAddrs;
+#[cfg(feature = "runtime-tokio")]
+use tokio::net::ToSocketAddrs;
 
 /// Returns the string replacing all the CRLF with "\<CRLF\>"
 /// Used for debug displays
@@ -115,7 +127,7 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
         timeout: Option<Duration>,
         tls_parameters: Option<&ClientTlsParameters>,
     ) -> Result<(), Error> {
-        let mut addresses = addr.to_socket_addrs().await?;
+        let mut addresses = lookup_host(addr).await?;
 
         let server_addr = match addresses.next() {
             Some(addr) => addr,
@@ -295,17 +307,52 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
     }
 }
 
+#[cfg(feature = "runtime-tokio")]
+pub(crate) async fn lookup_host<A: ToSocketAddrs>(
+    addr: A,
+) -> io::Result<impl Iterator<Item = SocketAddr>> {
+    tokio::net::lookup_host(addr).await
+}
+
+#[cfg(feature = "runtime-async-std")]
+pub(crate) async fn lookup_host<A: ToSocketAddrs>(
+    addr: A,
+) -> io::Result<impl Iterator<Item = SocketAddr>> {
+    addr.to_socket_addrs().await
+}
+
 /// Execute io operations with an optional timeout using.
+#[cfg(feature = "runtime-tokio")]
 pub(crate) async fn with_timeout<T, F, E>(
     timeout: Option<&Duration>,
     f: F,
 ) -> std::result::Result<T, E>
 where
     F: Future<Output = std::result::Result<T, E>>,
-    E: From<async_std::future::TimeoutError>,
+    E: From<tokio::time::error::Elapsed>,
 {
     if let Some(timeout) = timeout {
-        let res = async_std::future::timeout(*timeout, f).await??;
+        let res = tokio::time::timeout(*timeout, f).await??;
+        Ok(res)
+    } else {
+        f.await
+    }
+}
+
+/// Execute io operations with an optional timeout using.
+#[cfg(feature = "runtime-async-std")]
+pub(crate) async fn with_timeout<T, F, E>(
+    timeout: Option<&Duration>,
+    f: F,
+) -> std::result::Result<T, E>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+    E: From<io::Error>,
+{
+    if let Some(timeout) = timeout {
+        let res = async_std::future::timeout(*timeout, f)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::TimedOut, e))??;
         Ok(res)
     } else {
         f.await
@@ -315,10 +362,10 @@ where
 #[cfg(test)]
 mod test {
     use super::escape_crlf;
+    use crate::async_test;
     use crate::smtp::client::ClientCodec;
 
-    #[async_attributes::test]
-    async fn test_codec() {
+    async_test! { test_codec, {
         let mut codec = ClientCodec::new();
         let mut buf: Vec<u8> = vec![];
 
@@ -335,7 +382,7 @@ mod test {
             String::from_utf8(buf).unwrap(),
             "test\r\n..\r\n\r\ntestte\r\n..\r\nsttesttest.test\n.test\ntest"
         );
-    }
+    }}
 
     #[test]
     fn test_escape_crlf() {

--- a/src/smtp/client/inner.rs
+++ b/src/smtp/client/inner.rs
@@ -282,11 +282,11 @@ impl<S: Connector + Write + Read + Unpin> InnerClient<S> {
                     return Err(response.into());
                 }
                 Err(nom::Err::Failure(e)) => {
-                    return Err(Error::Parsing(e.1));
+                    return Err(Error::Parsing(e.code));
                 }
                 Err(nom::Err::Incomplete(_)) => { /* read more */ }
                 Err(nom::Err::Error(e)) => {
-                    return Err(Error::Parsing(e.1));
+                    return Err(Error::Parsing(e.code));
                 }
             }
         }

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -62,12 +62,12 @@ pub enum Error {
     Socks5Error(#[from] fast_socks5::SocksError),
 }
 
-impl From<nom::Err<(&str, nom::error::ErrorKind)>> for Error {
-    fn from(err: nom::Err<(&str, nom::error::ErrorKind)>) -> Error {
+impl From<nom::Err<nom::error::Error<&str>>> for Error {
+    fn from(err: nom::Err<nom::error::Error<&str>>) -> Error {
         Parsing(match err {
             nom::Err::Incomplete(_) => nom::error::ErrorKind::Complete,
-            nom::Err::Failure((_, k)) => k,
-            nom::Err::Error((_, k)) => k,
+            nom::Err::Failure(e) => e.code,
+            nom::Err::Error(e) => e.code,
         })
     }
 }

--- a/src/smtp/error.rs
+++ b/src/smtp/error.rs
@@ -47,6 +47,10 @@ pub enum Error {
     /// Parsing error
     #[error("parsing: {0:?}")]
     Parsing(nom::error::ErrorKind),
+    #[cfg(feature = "runtime-tokio")]
+    #[error("timeout: {0}")]
+    Timeout(#[from] tokio::time::error::Elapsed),
+    #[cfg(feature = "runtime-async-std")]
     #[error("timeout: {0}")]
     Timeout(#[from] async_std::future::TimeoutError),
     #[error("no stream")]

--- a/src/smtp/response.rs
+++ b/src/smtp/response.rs
@@ -253,7 +253,10 @@ pub(crate) fn parse_response(i: &str) -> IResult<&str, Response> {
 
     // Check that all codes are equal.
     if !lines.iter().all(|&(ref code, _, _)| *code == last_code) {
-        return Err(nom::Err::Failure(("", nom::error::ErrorKind::Not)));
+        return Err(nom::Err::Failure(nom::error::Error {
+            input: "",
+            code: nom::error::ErrorKind::Not,
+        }));
     }
 
     // Extract text from lines, and append last line.

--- a/tests/transport_file.rs
+++ b/tests/transport_file.rs
@@ -2,40 +2,41 @@
 #[cfg(feature = "file-transport")]
 mod test {
     use async_smtp::file::FileTransport;
-    use async_smtp::{EmailAddress, Envelope, SendableEmail, Transport};
+    use async_smtp::{async_test, EmailAddress, Envelope, SendableEmail, Transport};
 
     use std::env::temp_dir;
     use std::fs::remove_file;
     use std::fs::File;
     use std::io::Read;
 
-    #[async_attributes::test]
-    async fn file_transport() {
-        let mut sender = FileTransport::new(temp_dir());
-        let email = SendableEmail::new(
-            Envelope::new(
-                Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
-                vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
-            )
-            .unwrap(),
-            "id".to_string(),
-            "Hello ß☺ example".to_string().into_bytes(),
-        );
-        let message_id = email.message_id().to_string();
+    async_test! {
+        file_transport, {
+            let mut sender = FileTransport::new(temp_dir());
+            let email = SendableEmail::new(
+                Envelope::new(
+                    Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
+                    vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
+                )
+                    .unwrap(),
+                "id".to_string(),
+                "Hello ß☺ example".to_string().into_bytes(),
+            );
+            let message_id = email.message_id().to_string();
 
-        let result = sender.send(email).await;
-        assert!(result.is_ok());
+            let result = sender.send(email).await;
+            assert!(result.is_ok());
 
-        let file = format!("{}/{}.json", temp_dir().to_str().unwrap(), message_id);
-        let mut f = File::open(file.clone()).unwrap();
-        let mut buffer = String::new();
-        let _ = f.read_to_string(&mut buffer);
+            let file = format!("{}/{}.json", temp_dir().to_str().unwrap(), message_id);
+            let mut f = File::open(file.clone()).unwrap();
+            let mut buffer = String::new();
+            let _ = f.read_to_string(&mut buffer);
 
-        assert_eq!(
-            buffer,
-            "{\"envelope\":{\"forward_path\":[\"root@localhost\"],\"reverse_path\":\"user@localhost\"},\"message_id\":\"id\",\"message\":[72,101,108,108,111,32,195,159,226,152,186,32,101,120,97,109,112,108,101]}"
-        );
+            assert_eq!(
+                buffer,
+                "{\"envelope\":{\"forward_path\":[\"root@localhost\"],\"reverse_path\":\"user@localhost\"},\"message_id\":\"id\",\"message\":[72,101,108,108,111,32,195,159,226,152,186,32,101,120,97,109,112,108,101]}"
+            );
 
-        remove_file(file).unwrap();
+            remove_file(file).unwrap();
+        }
     }
 }

--- a/tests/transport_sendmail.rs
+++ b/tests/transport_sendmail.rs
@@ -2,23 +2,25 @@
 #[cfg(feature = "sendmail-transport")]
 mod test {
     use async_smtp::sendmail::SendmailTransport;
-    use async_smtp::{EmailAddress, Envelope, SendableEmail, Transport};
+    use async_smtp::{async_test, EmailAddress, Envelope, SendableEmail, Transport};
 
-    #[async_attributes::test]
-    async fn sendmail_transport_simple() {
-        let mut sender = SendmailTransport::new();
-        let email = SendableEmail::new(
-            Envelope::new(
-                Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
-                vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
-            )
-            .unwrap(),
-            "id".to_string(),
-            "Hello ß☺ example".to_string().into_bytes(),
-        );
+    async_test! {
+        sendmail_transport_simple,
+        {
+            let mut sender = SendmailTransport::new();
+            let email = SendableEmail::new(
+                Envelope::new(
+                    Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
+                    vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
+                )
+                    .unwrap(),
+                "id".to_string(),
+                "Hello ß☺ example".to_string().into_bytes(),
+            );
 
-        let result = sender.send(email).await;
-        println!("{:?}", result);
-        assert!(result.is_ok());
+            let result = sender.send(email).await;
+            println!("{:?}", result);
+            assert!(result.is_ok());
+        }
     }
 }

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -1,35 +1,36 @@
 #[cfg(test)]
 #[cfg(feature = "smtp-transport")]
 mod test {
-    use async_smtp::{ClientSecurity, Envelope, SendableEmail, ServerAddress, SmtpClient};
+    use async_smtp::{
+        async_test_ignore, ClientSecurity, Envelope, SendableEmail, ServerAddress, SmtpClient,
+    };
 
-    #[async_attributes::test]
-    #[ignore] // ignored as this needs a running server
-    async fn smtp_transport_simple() {
-        let email = SendableEmail::new(
-            Envelope::new(
-                Some("user@localhost".parse().unwrap()),
-                vec!["root@localhost".parse().unwrap()],
-            )
-            .unwrap(),
-            "id",
-            "From: user@localhost\r\n\
-             Content-Type: text/plain\r\n\
-             \r\n\
-             Hello example",
-        );
-
-        println!("connecting");
-        let mut transport = SmtpClient::with_security(
-            ServerAddress {
-                host: "127.0.0.1".to_string(),
-                port: 3025,
-            },
-            ClientSecurity::None,
+    // ignored as this needs a running server
+    async_test_ignore! { smtp_transport_simple, {
+    let email = SendableEmail::new(
+        Envelope::new(
+            Some("user@localhost".parse().unwrap()),
+            vec!["root@localhost".parse().unwrap()],
         )
-        .into_transport();
+        .unwrap(),
+        "id",
+        "From: user@localhost\r\n\
+         Content-Type: text/plain\r\n\
+         \r\n\
+         Hello example",
+    );
 
-        println!("sending");
-        transport.connect_and_send(email).await.unwrap();
-    }
+    println!("connecting");
+    let mut transport = SmtpClient::with_security(
+        ServerAddress {
+            host: "127.0.0.1".to_string(),
+            port: 3025,
+        },
+        ClientSecurity::None,
+    )
+    .into_transport();
+
+    println!("sending");
+    transport.connect_and_send(email).await.unwrap();
+    }}
 }

--- a/tests/transport_stub.rs
+++ b/tests/transport_stub.rs
@@ -2,10 +2,9 @@
 #[cfg(feature = "smtp-transport")]
 mod test {
     use async_smtp::stub::StubTransport;
-    use async_smtp::{EmailAddress, Envelope, SendableEmail, Transport};
+    use async_smtp::{async_test, EmailAddress, Envelope, SendableEmail, Transport};
 
-    #[async_attributes::test]
-    async fn stub_transport() {
+    async_test! { stub_transport, {
         let mut sender_ok = StubTransport::new_positive();
         let mut sender_ko = StubTransport::new(Err(()));
         let email_ok = SendableEmail::new(
@@ -29,5 +28,5 @@ mod test {
 
         sender_ok.send(email_ok).await.unwrap();
         sender_ko.send(email_ko).await.unwrap_err();
-    }
+    }}
 }


### PR DESCRIPTION
Allows configuration of either tokio or async-std.
Drops support for `socks5` with `async-std`, as the underlying library `fast-sockst5` has done so in the latest release.