### PR TITLE
Do not wrap the stream into BufReader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ pin-project = "1"
 anyhow = "1"
 async-std = { version = "1.11", features = ["unstable"], optional = true }
 base64 = "^0.13"
-bufstream = "^0.1"
 futures = "0.3.21"
 hostname = "0.3.1"
 log = "^0.4"

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -1,3 +1,4 @@
+use tokio::io::BufStream;
 use tokio::net::TcpStream;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -7,7 +8,7 @@ use async_smtp::{Envelope, SendableEmail, SmtpClient, SmtpTransport};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let stream = TcpStream::connect("127.0.0.1:2525").await?;
+    let stream = BufStream::new(TcpStream::connect("127.0.0.1:2525").await?);
     let client = SmtpClient::new();
     let mut transport = SmtpTransport::new(client, stream).await?;
 

--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -10,9 +10,9 @@ use crate::stream::SmtpStream;
 use crate::SendableEmail;
 
 #[cfg(feature = "runtime-async-std")]
-use async_std::io::{Read, Write};
+use async_std::io::{BufRead, Write};
 #[cfg(feature = "runtime-tokio")]
-use tokio::io::{AsyncRead as Read, AsyncWrite as Write};
+use tokio::io::{AsyncBufRead as BufRead, AsyncWrite as Write};
 
 /// Contains client configuration
 #[derive(Debug)]
@@ -91,7 +91,7 @@ impl SmtpClient {
 
 /// Structure that implements the high level SMTP client
 #[derive(Debug)]
-pub struct SmtpTransport<S: Read + Write + Unpin> {
+pub struct SmtpTransport<S: BufRead + Write + Unpin> {
     /// Information about the server
     server_info: ServerInfo,
     /// Information about the client
@@ -100,7 +100,7 @@ pub struct SmtpTransport<S: Read + Write + Unpin> {
     stream: SmtpStream<S>,
 }
 
-impl<S: Read + Write + Unpin> SmtpTransport<S> {
+impl<S: BufRead + Write + Unpin> SmtpTransport<S> {
     /// Creates a new SMTP transport and connects.
     pub async fn new(builder: SmtpClient, stream: S) -> Result<Self, Error> {
         let mut stream = SmtpStream::new(stream);


### PR DESCRIPTION
Require that the stream implements BufRead trait instead. Crate user may choose to wrap the stream into BufReader, BufStream or implement buffering some other way.