### PR TITLE
feat: Add ability to get SmtpStream from SmtpTransport

### DIFF
--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -123,9 +123,19 @@ impl<S: BufRead + Write + Unpin> SmtpTransport<S> {
         Ok(transport)
     }
 
-    /// Get the underlying SmtpStream.
-    pub fn get_stream(&mut self) -> &mut SmtpStream<S> {
+    /// Gets a mutable reference to the underlying `SmtpStream`.
+    pub fn get_mut(&mut self) -> &mut SmtpStream<S> {
         &mut self.stream
+    }
+
+    /// Gets a reference to the underlying `SmtpStream``.
+    pub fn get_ref(&mut self) -> &SmtpStream<S> {
+        &self.stream
+    }
+
+    /// Consumes the SMTP transport and returns the inner `SmtpStream`.
+    pub fn into_inner(self) -> SmtpStream<S> {
+        self.stream
     }
 
     /// Try to login with the given accepted mechanisms.

--- a/src/smtp_client.rs
+++ b/src/smtp_client.rs
@@ -123,6 +123,11 @@ impl<S: BufRead + Write + Unpin> SmtpTransport<S> {
         Ok(transport)
     }
 
+    /// Get the underlying SmtpStream.
+    pub fn get_stream(&mut self) -> &mut SmtpStream<S> {
+        &mut self.stream
+    }
+
     /// Try to login with the given accepted mechanisms.
     pub async fn try_login(
         &mut self,


### PR DESCRIPTION
I am the author of https://github.com/reacherhq/check-if-email-exists, and I currently use async-smtp 0.6. I would like to upgrade to 0.9, but I'm blocked on one small feature missing in this library.

The check-if-email-exists lib manually sends the EHLO, MAIL FROM, RCPT commands, but does not actually send the email. Looking at the SmtpClient, it only exposes the `send()` function, which does MAIL FROM, RCPT, DATA and sending. It seems like there's no way to have more granularity on the SMTP commands.

I would like to propose this small addition so that I can upgrade to 0.9 and continue using this great library without forking.

Thanks for considering.